### PR TITLE
Created and added base 'view all' reactors page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Login from './pages/Login';
 
 import { useState, useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
+import Reactors from './pages/Reactors';
 
 function App() {
   let [data, setData] = useState([]);
@@ -29,6 +30,15 @@ function App() {
           element={
             <>
               <Landing data={data} />
+            </>
+          }
+        />
+
+        <Route
+          path='/reactors'
+          element={
+            <>
+              <Reactors data={data} />
             </>
           }
         />

--- a/src/assets/App.css
+++ b/src/assets/App.css
@@ -367,8 +367,9 @@ html {
   width: 67.6667%;
 }
 .container__sidebar {
+  max-width: 300px;
   background-color: var(--white);
-  padding: 1rem;
+  padding: 1rem 1.5rem 1rem 1.5rem;
   border: 1px solid var(--grey__light);
   border-radius: 6px;
   margin-right: 1rem;
@@ -379,6 +380,25 @@ html {
 .container__scrollMain {
   padding-top: 1rem;
   padding-left: 1.25rem;
+}
+.categoryList {
+  list-style: none;
+  padding-left: 0;
+}
+.categoryList__link {
+  text-decoration: none;
+}
+.categoryList__item {
+  color: var(--purple__grey);
+  border-radius: 4px;
+  font-size: 1.1rem;
+  font-weight: 500;
+  padding: 1rem;
+  transition: all ease-in-out 75ms;
+}
+.categoryList__item:hover {
+  color: var(--purple__light--extra);
+  background-color: var(--purple__primary);
 }
 
 .container__cards--all {

--- a/src/assets/App.css
+++ b/src/assets/App.css
@@ -343,7 +343,7 @@ html {
   flex-wrap: wrap;
 }
 /* Modal styling */
-.modal-window {
+.modal__window {
   position: fixed;
   background-color: rgba(255, 255, 255, 0.25);
   top: 0;
@@ -353,26 +353,30 @@ html {
   z-index: 999;
   visibility: hidden;
   opacity: 0;
+  backdrop-filter: blur(5px);
   pointer-events: none;
-  transition: all 0.3s;
+  transition: all 0.15s;
 }
-.modal-window:target {
+.modal__window:target {
   visibility: visible;
   opacity: 1;
   pointer-events: auto;
 }
-.modal-window > div {
-  max-width: 95vw;
-  min-height: 250px;
-  max-height: 95vh;
+.modal__window > .modal__inner {
+  width: 90vw;
+  max-width: 1500px;
+  max-height: 90vh;
   position: absolute;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
   padding: 2em;
+  transform: translate(-50%, -50%);
+  border: 1px solid var(--grey__light);
+  border-radius: 4px;
   background: white;
+  overflow-y: auto;
 }
-.modal-close {
+.modal__close {
   color: #aaa;
   line-height: 50px;
   font-size: 80%;
@@ -383,7 +387,7 @@ html {
   width: 70px;
   text-decoration: none;
 }
-.modal-close:hover {
+.modal__close:hover {
   color: black;
 }
 /************* '/reactors' route styling Reactors Page Styling *************/
@@ -395,10 +399,14 @@ html {
   background-color: var(--purple__light--extra);
 }
 .container__reactors {
+  max-width: 1400px;
   margin-top: 3rem;
+}
+.container__header {
   max-width: 800px;
 }
 .container__flex {
+  max-width: 1400px;
   display: flex;
   padding-top: 2.5rem;
   border-top: 1px solid var(--grey__light);
@@ -458,11 +466,13 @@ html {
   min-height: 255px;
   transition: all ease-in-out 75ms;
 }
-.card__reactorData--all .card__title {
+.card__reactorData--all .card__title,
+.modal-window .card__title {
   margin-bottom: 0;
   color: var(--purple__grey);
 }
-.card__reactorData--all .card__subtitle {
+.card__reactorData--all .card__subtitle,
+.modal-window .card__subtitle {
   margin-top: 0;
   font-weight: 500;
   color: var(--purple__accent--primary);
@@ -493,6 +503,21 @@ html {
 }
 .card__icon {
   color: var(--purple__secondary);
+}
+.tableModal {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  margin-bottom: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--grey__light);
+}
+.tableModal__title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  width: 25%;
+}
+.tableModal__data {
 }
 
 /************* '/about' route styling About Page Styling *************/

--- a/src/assets/App.css
+++ b/src/assets/App.css
@@ -342,7 +342,50 @@ html {
   gap: 0 4rem;
   flex-wrap: wrap;
 }
-
+/* Modal styling */
+.modal-window {
+  position: fixed;
+  background-color: rgba(255, 255, 255, 0.25);
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 999;
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transition: all 0.3s;
+}
+.modal-window:target {
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+}
+.modal-window > div {
+  max-width: 95vw;
+  min-height: 250px;
+  max-height: 95vh;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 2em;
+  background: white;
+}
+.modal-close {
+  color: #aaa;
+  line-height: 50px;
+  font-size: 80%;
+  position: absolute;
+  right: 0;
+  text-align: center;
+  top: 0;
+  width: 70px;
+  text-decoration: none;
+}
+.modal-close:hover {
+  color: black;
+}
 /************* '/reactors' route styling Reactors Page Styling *************/
 .section__reactors {
   min-height: 100vh;

--- a/src/assets/App.css
+++ b/src/assets/App.css
@@ -508,9 +508,9 @@ html {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
-  margin-bottom: 1rem;
-  padding-bottom: 1rem;
-  border-bottom: 1px solid var(--grey__light);
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--grey__light);
 }
 .tableModal__title {
   font-size: 1.05rem;
@@ -586,6 +586,13 @@ pre > span {
   /* border: 1px solid var(--grey__light); */
 }
 /************* Media Queries & Mobile Responsiveness *************/
+/* md */
+@media screen and (max-width: 950px) {
+  /* View all reactors Page */
+  .card__reactorData--all {
+    width: 85.5%;
+  }
+}
 
 /* sm */
 @media screen and (max-width: 530px) {
@@ -660,6 +667,30 @@ pre > span {
   }
   .reactorData__detail {
     font-size: 1.15rem;
+  }
+  /* View all reactors Page */
+  .container__flex {
+    display: block;
+  }
+  .col--side {
+    width: 100%;
+  }
+  .col--main {
+    width: 100%;
+  }
+  .container__scrollMain {
+    padding-left: 0;
+  }
+  .container__sidebar {
+    max-width: 100%;
+    margin-right: 0;
+  }
+  .card__reactorData--all {
+    width: 100%;
+    max-width: 100%;
+  }
+  .tableModal__title {
+    width: 100%;
   }
   /* About page */
   .container__body {

--- a/src/assets/App.css
+++ b/src/assets/App.css
@@ -353,6 +353,7 @@ html {
 }
 .container__reactors {
   margin-top: 3rem;
+  max-width: 800px;
 }
 .container__flex {
   display: flex;
@@ -372,10 +373,27 @@ html {
   border-radius: 6px;
   margin-right: 1rem;
 }
+.sidebar__title {
+  color: var(--purple__grey);
+}
 .container__scrollMain {
   padding-top: 1rem;
   padding-left: 1.25rem;
 }
+
+.container__cards--all {
+  justify-content: space-between;
+  gap: 2rem;
+}
+.card__reactorData--all {
+  background-color: var(--white);
+  border: 1px solid var(--grey__light);
+  width: 47.5%;
+}
+.card__reactorData--all > .card__title {
+  color: var(--purple__grey);
+}
+
 /************* '/about' route styling About Page Styling *************/
 .section__about,
 .section__login {

--- a/src/assets/App.css
+++ b/src/assets/App.css
@@ -386,18 +386,50 @@ html {
   gap: 2rem;
 }
 .card__reactorData--all {
+  display: flex;
+  flex-direction: column;
   background-color: var(--white);
   border: 1px solid var(--grey__light);
   width: 47.5%;
+  max-width: 425px;
+  min-height: 255px;
   transition: all ease-in-out 75ms;
 }
-.card__reactorData--all > .card__title {
+.card__reactorData--all .card__title {
+  margin-bottom: 0;
   color: var(--purple__grey);
+}
+.card__reactorData--all .card__subtitle {
+  margin-top: 0;
+  font-weight: 500;
+  color: var(--purple__accent--primary);
 }
 .card__reactorData--all:hover {
   background-color: rgb(243 243 254);
   border: 1px solid rgb(101 108 246);
   border-radius: 4px;
+}
+.link__modal {
+  text-decoration: none;
+}
+.link__modal--button {
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-end;
+  color: var(--purple__grey);
+}
+.link__modal--button:hover {
+  color: var(--purple__accent--primary);
+}
+.card__reactorData--all .card__title:hover {
+  color: var(--purple__accent--primary);
+}
+.card__reactorProp {
+  display: block;
+  color: var(--purple__grey);
+}
+.card__icon {
+  color: var(--purple__secondary);
 }
 
 /************* '/about' route styling About Page Styling *************/

--- a/src/assets/App.css
+++ b/src/assets/App.css
@@ -354,6 +354,28 @@ html {
 .container__reactors {
   margin-top: 3rem;
 }
+.container__flex {
+  display: flex;
+  padding-top: 2.5rem;
+  border-top: 1px solid var(--grey__light);
+}
+.col--side {
+  width: 33.3333%;
+}
+.col--main {
+  width: 67.6667%;
+}
+.container__sidebar {
+  background-color: var(--white);
+  padding: 1rem;
+  border: 1px solid var(--grey__light);
+  border-radius: 6px;
+  margin-right: 1rem;
+}
+.container__scrollMain {
+  padding-top: 1rem;
+  padding-left: 1.25rem;
+}
 /************* '/about' route styling About Page Styling *************/
 .section__about,
 .section__login {

--- a/src/assets/App.css
+++ b/src/assets/App.css
@@ -389,9 +389,15 @@ html {
   background-color: var(--white);
   border: 1px solid var(--grey__light);
   width: 47.5%;
+  transition: all ease-in-out 75ms;
 }
 .card__reactorData--all > .card__title {
   color: var(--purple__grey);
+}
+.card__reactorData--all:hover {
+  background-color: rgb(243 243 254);
+  border: 1px solid rgb(101 108 246);
+  border-radius: 4px;
 }
 
 /************* '/about' route styling About Page Styling *************/

--- a/src/assets/App.css
+++ b/src/assets/App.css
@@ -101,6 +101,9 @@ html {
   border: 2px solid var(--purple__primary);
   background-color: var(--purple__primary);
 }
+.page__contentDescrip {
+  font-weight: 500;
+}
 
 /************* Header Component Styling *************/
 .section__header {
@@ -340,6 +343,17 @@ html {
   flex-wrap: wrap;
 }
 
+/************* '/reactors' route styling Reactors Page Styling *************/
+.section__reactors {
+  min-height: 100vh;
+  padding-top: 6.5rem;
+  padding-left: 2.5rem;
+  padding-right: 2.5rem;
+  background-color: var(--purple__light--extra);
+}
+.container__reactors {
+  margin-top: 3rem;
+}
 /************* '/about' route styling About Page Styling *************/
 .section__about,
 .section__login {
@@ -363,10 +377,6 @@ html {
   padding-bottom: 2.5rem;
   align-items: flex-start;
   border-bottom: 1px solid var(--grey__light);
-}
-.section__about p,
-.section__login p {
-  font-weight: 500;
 }
 .container__body {
   min-width: 100%;
@@ -413,6 +423,10 @@ pre > span {
 
 /* sm */
 @media screen and (max-width: 530px) {
+  /* General */
+  .page__header {
+    font-size: 1.875rem;
+  }
   /* Header & Nav */
   .section__header {
     padding: 0 1.15rem;
@@ -444,7 +458,8 @@ pre > span {
     padding: 5vh 1rem 5vh 1rem;
   }
   .section__about,
-  .section__login {
+  .section__login,
+  .section__reactors {
     padding: 100px 1rem;
   }
   .container__appDesc > .text__appDesc {

--- a/src/components/CategoryList.jsx
+++ b/src/components/CategoryList.jsx
@@ -1,0 +1,23 @@
+import '../assets/App.css';
+
+function CategoryList({ data }) {
+  let categories = [...new Set([...data].map((reactor) => reactor.type))];
+
+  let category = categories.map((type) => {
+    return (
+      <li className='categoryList__item' key={type}>
+        {type}
+      </li>
+    );
+  });
+
+  return (
+    <ul className='categoryList'>
+      <a className='categoryList__link' href='#'>
+        {category}
+      </a>
+    </ul>
+  );
+}
+
+export default CategoryList;

--- a/src/components/ReactorCard.jsx
+++ b/src/components/ReactorCard.jsx
@@ -1,4 +1,5 @@
 import '../assets/App.css';
+import ReactorModal from '../components/ReactorModal';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faFireFlameSimple,
@@ -11,39 +12,48 @@ import {
 function ReactorCard({ data }) {
   let card = data.map((reactor) => {
     return (
-      // Reactor Card
-      <div
-        className='card--light card__reactorData card__reactorData--all'
-        key={reactor.name}
-      >
-        <a className='link__modal' href='#'>
-          <h3 className='card__title'>{reactor.name}</h3>
-        </a>
-        <p className='card__subtitle'>{reactor.fullName}</p>
-        <div className='card__reactorProperties'>
-          <span className='card__reactorProp'>
-            <FontAwesomeIcon className='card__icon' icon={faGlobe} />{' '}
-            {reactor.designOrg}
-          </span>
-          <span className='card__reactorProp'>
-            <FontAwesomeIcon className='card__icon' icon={faAtom} />{' '}
-            {reactor.type} ({reactor.coolant})
-          </span>
-          <span className='card__reactorProp'>
-            <FontAwesomeIcon className='card__icon' icon={faLightbulb} />{' '}
-            {reactor.outputGross} MWe (gross)
-          </span>
-          <span className='card__reactorProp'>
-            <FontAwesomeIcon className='card__icon' icon={faFireFlameSimple} />{' '}
-            {reactor.thermalOutput} MWth
-          </span>
+      <>
+        {/* Reactor Card Main */}
+        <div
+          className='card--light card__reactorData card__reactorData--all'
+          key={reactor.name}
+        >
+          <a className='link__modal' href={`#${reactor.name}`}>
+            <h3 className='card__title'>{reactor.name}</h3>
+          </a>
+          <p className='card__subtitle'>{reactor.fullName}</p>
+          <div className='card__reactorProperties'>
+            <span className='card__reactorProp'>
+              <FontAwesomeIcon className='card__icon' icon={faGlobe} />{' '}
+              {reactor.designOrg}
+            </span>
+            <span className='card__reactorProp'>
+              <FontAwesomeIcon className='card__icon' icon={faAtom} />{' '}
+              {reactor.type} ({reactor.coolant})
+            </span>
+            <span className='card__reactorProp'>
+              <FontAwesomeIcon className='card__icon' icon={faLightbulb} />{' '}
+              {reactor.outputGross} MWe (gross)
+            </span>
+            <span className='card__reactorProp'>
+              <FontAwesomeIcon
+                className='card__icon'
+                icon={faFireFlameSimple}
+              />{' '}
+              {reactor.thermalOutput} MWth
+            </span>
+          </div>
+          <a
+            className='link__modal link__modal--button'
+            href={`#${reactor.name}`}
+          >
+            <FontAwesomeIcon className='' icon={faExternalLinkAlt} />
+          </a>
         </div>
-        <a className='link__modal link__modal--button' href='#'>
-          <FontAwesomeIcon className='' icon={faExternalLinkAlt} />
-        </a>
-      </div>
 
-      // TODO: Modal
+        {/* Reactor Modal Pop out */}
+        <ReactorModal reactor={reactor} />
+      </>
     );
   });
 

--- a/src/components/ReactorCard.jsx
+++ b/src/components/ReactorCard.jsx
@@ -1,14 +1,49 @@
 import '../assets/App.css';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faFireFlameSimple,
+  faAtom,
+  faGlobe,
+  faLightbulb,
+  faExternalLinkAlt,
+} from '@fortawesome/free-solid-svg-icons';
 
 function ReactorCard({ data }) {
   let card = data.map((reactor) => {
     return (
+      // Reactor Card
       <div
         className='card--light card__reactorData card__reactorData--all'
         key={reactor.name}
       >
-        <h3 className='card__title'>{reactor.name}</h3>
+        <a className='link__modal' href='#'>
+          <h3 className='card__title'>{reactor.name}</h3>
+        </a>
+        <p className='card__subtitle'>{reactor.fullName}</p>
+        <div className='card__reactorProperties'>
+          <span className='card__reactorProp'>
+            <FontAwesomeIcon className='card__icon' icon={faGlobe} />{' '}
+            {reactor.designOrg}
+          </span>
+          <span className='card__reactorProp'>
+            <FontAwesomeIcon className='card__icon' icon={faAtom} />{' '}
+            {reactor.type} ({reactor.coolant})
+          </span>
+          <span className='card__reactorProp'>
+            <FontAwesomeIcon className='card__icon' icon={faLightbulb} />{' '}
+            {reactor.outputGross} MWe (gross)
+          </span>
+          <span className='card__reactorProp'>
+            <FontAwesomeIcon className='card__icon' icon={faFireFlameSimple} />{' '}
+            {reactor.thermalOutput} MWth
+          </span>
+        </div>
+        <a className='link__modal link__modal--button' href='#'>
+          <FontAwesomeIcon className='' icon={faExternalLinkAlt} />
+        </a>
       </div>
+
+      // TODO: Modal
     );
   });
 

--- a/src/components/ReactorCard.jsx
+++ b/src/components/ReactorCard.jsx
@@ -1,0 +1,22 @@
+import '../assets/App.css';
+
+function ReactorCard({ data }) {
+  let card = data.map((reactor) => {
+    return (
+      <div
+        className='card--light card__reactorData card__reactorData--all'
+        key={reactor.name}
+      >
+        <h3 className='card__title'>{reactor.name}</h3>
+      </div>
+    );
+  });
+
+  return (
+    <div className='container container__cards container__cards--all'>
+      {card}
+    </div>
+  );
+}
+
+export default ReactorCard;

--- a/src/components/ReactorModal.jsx
+++ b/src/components/ReactorModal.jsx
@@ -1,0 +1,25 @@
+import '../assets/App.css';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faFireFlameSimple,
+  faAtom,
+  faGlobe,
+  faLightbulb,
+  faExternalLinkAlt,
+} from '@fortawesome/free-solid-svg-icons';
+
+function ReactorModal({ reactor }) {
+  return (
+    <div id={reactor.name} className='modal-window'>
+      <div>
+        <a href='#' title='Close' className='modal-close'>
+          Close
+        </a>
+        <h3 className='card__title'>{reactor.name}</h3>
+        <p className='card__subtitle'>{reactor.fullName}</p>
+      </div>
+    </div>
+  );
+}
+
+export default ReactorModal;

--- a/src/components/ReactorModal.jsx
+++ b/src/components/ReactorModal.jsx
@@ -10,13 +10,205 @@ import {
 
 function ReactorModal({ reactor }) {
   return (
-    <div id={reactor.name} className='modal-window'>
-      <div>
-        <a href='#' title='Close' className='modal-close'>
+    <div id={reactor.name} className='modal__window'>
+      <div className='modal__inner'>
+        <a href='#' title='Close' className='modal__close'>
           Close
         </a>
         <h3 className='card__title'>{reactor.name}</h3>
         <p className='card__subtitle'>{reactor.fullName}</p>
+
+        <table className='table tableModal'>
+          <thead className='tableModal__title'>Overview</thead>
+          <tbody className='tableModal__data'>
+            <tr className='tableModal__row'>
+              <td>Vendor</td>
+              <td>
+                <a href={reactor.designOrgWebsite}>{reactor.designOrg}</a>
+              </td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Country of Origin</td>
+              <td>{reactor.country}</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Design Status</td>
+              <td>{reactor.designStatus}</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Purpose</td>
+              <td>{reactor.purpose}</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Non-electrical Applications</td>
+              <td>{reactor.nonElecApplications}</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Reactor Type</td>
+              <td>{reactor.type}</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Neutron Spectrum</td>
+              <td>{reactor.neutronSpectrum}</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Coolant</td>
+              <td>{reactor.coolant}</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Moderator</td>
+              <td>{reactor.moderator}</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Power Plant Net Output</td>
+              <td>{`${reactor.outputNet} MWe`}</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Power Plant Gross Output</td>
+              <td>{`${reactor.outputGross} MWe`}</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Reactor Thermal Output</td>
+              <td>{`${reactor.thermalOutput} MWth`}</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <table className='table tableModal'>
+          <thead className='tableModal__title'>Coolant System</thead>
+          <tbody className='tableModal__data'>
+            <tr className='tableModal__row'>
+              <td>Coolant</td>
+              <td>{reactor.coolant}</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Primary Flow Rate</td>
+              <td>{reactor.primaryCoolantFlowRate} kg/s</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Operating Pressure</td>
+              <td>{reactor.operatingPressure} MPa</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Inlet Temperature</td>
+              <td>{reactor.coolantInletTemp} &#8451;</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Outlet Temperature</td>
+              <td>{reactor.coolantOutletTemp} &#8451;</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Delta Temperature</td>
+              <td>{reactor.deltaTemp} &#8451;</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <table className='table tableModal'>
+          <thead className='tableModal__title'>Reactor Core</thead>
+          <tbody className='tableModal__data'>
+            <tr className='tableModal__row'>
+              <td>Active Core Height</td>
+              <td>{reactor.coreHeight} m</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Equivalent Core Diameter</td>
+              <td>{reactor.equivCoreDiameter} m</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Avg Linear Heat Rate</td>
+              <td>{reactor.avgLinearHeatRate} kW/m</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Avg Fuel Power Density</td>
+              <td>{reactor.avgFuelPowerDensity} kW/kgU</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Avg Core Power Density</td>
+              <td>{reactor.avgCorePowerDensity} kW/kgU</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Outer Diameter of Fuel Rods</td>
+              <td>{reactor.outerCoreDiameterFuelRods} mm</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Rod Array of Fuel Assembly</td>
+              <td>{reactor.rodArray}</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Lattice Geometry</td>
+              <td>{reactor.latticeGeometry}</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Number of Fuel Assemblies</td>
+              <td>{reactor.numOfFuelAssemblies}</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <table className='table tableModal'>
+          <thead className='tableModal__title'>Core Materials</thead>
+          <tbody className='tableModal__data'>
+            <tr className='tableModal__row'>
+              <td>Fuel Material</td>
+              <td>{reactor.fuelMaterial}</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Cladding Material</td>
+              <td>{reactor.claddingMaterial}</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Enrichment of Reload Fuel</td>
+              <td>{reactor.reloadFuelEnrichment} wt %</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Fuel Cycle Length</td>
+              <td>{reactor.fuelCycleLength} months</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Avg Discharge Burnup</td>
+              <td>{reactor.avgDischargeBurnup} MWd/kg</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Burnable Absorber</td>
+              <td>{reactor.burnableAbsorber}</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Control Rod Absorber</td>
+              <td>{reactor.controlRodAbsorber}</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Soluble Neutron Absorber</td>
+              <td>{reactor.solubleNeutronAbsorber}</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <table className='table tableModal'>
+          <thead className='tableModal__title'>Pressure Vessel</thead>
+          <tbody className='tableModal__data'>
+            <tr className='tableModal__row'>
+              <td>Inner Diameter of Cylindrical Shell</td>
+              <td>{reactor.innerDiameterCylindricalShell} mm</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Wall Thickness of Cylindrical Shell</td>
+              <td>{reactor.wallThicknessCylindricalShell} mm</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Base Material</td>
+              <td>{reactor.baseMaterial}</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Total Height, Inside</td>
+              <td>{reactor.totHeightInside} mm</td>
+            </tr>
+            <tr className='tableModal__row'>
+              <td>Transport Weight</td>
+              <td>{reactor.transportWeight} tonne</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
   );

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -6,7 +6,7 @@ function About() {
     <section className='section__about'>
       <div className='container container__desc'>
         <h1 className='page__header'>Advanced Reactor DataBase API</h1>
-        <p>
+        <p className='page__contentDescrip'>
           The arDB API is written with Node, Express, and Mongoose, with source
           data scraped using Puppeteer and Cheerio. The client site is built in
           React. We try our best to follow documentation and specs to prevent

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -6,7 +6,9 @@ function Login() {
     <div className='section__login'>
       <div className='container container__login'>
         <h1 className='page__header'>Developer Login</h1>
-        <p>Login and update your organization's reactor information</p>
+        <p className='page__contentDescrip'>
+          Login and update your organization's reactor information
+        </p>
         <p>
           <b>UNDER CONSTRUCTION</b>
         </p>

--- a/src/pages/Reactors.jsx
+++ b/src/pages/Reactors.jsx
@@ -1,4 +1,5 @@
 import '../assets/App.css';
+import CategoryList from '../components/CategoryList';
 import ReactorCard from '../components/ReactorCard';
 import Footer from '../components/Footer';
 
@@ -22,6 +23,7 @@ function Reactors({ data }) {
         <div className='col col--side'>
           <div className='container__sidebar'>
             <h2 className='sidebar__title'>Categories</h2>
+            <CategoryList data={data} />
           </div>
         </div>
         {/* Displays all reactors in cards */}

--- a/src/pages/Reactors.jsx
+++ b/src/pages/Reactors.jsx
@@ -1,0 +1,24 @@
+import '../assets/App.css';
+import Footer from '../components/Footer';
+
+function Reactors() {
+  return (
+    <section className='section__reactors'>
+      <div className='container container__reactors'>
+        <h1 className='page__header'>
+          Open Source Data for Professionals and Developers
+        </h1>
+        <p className='page__contentDescrip'>
+          You are exploring all available scraped datasets from all categories.
+          Available data includes reactor information related to design
+          specifications, reactor core, coolant system, core materials, and
+          more. If you find new data or would like to provide updates, feel free
+          to login and submit a request.
+        </p>
+      </div>
+      <Footer />
+    </section>
+  );
+}
+
+export default Reactors;

--- a/src/pages/Reactors.jsx
+++ b/src/pages/Reactors.jsx
@@ -7,16 +7,18 @@ function Reactors({ data }) {
   return (
     <section className='section__reactors'>
       <div className='container container__reactors'>
-        <h1 className='page__header'>
-          Open Source Data for Professionals and Developers
-        </h1>
-        <p className='page__contentDescrip'>
-          You are exploring all available scraped datasets from all categories.
-          Available data includes reactor information related to design
-          specifications, reactor core, coolant system, core materials, and
-          more. If you find new data or would like to provide updates, feel free
-          to login and submit a request.
-        </p>
+        <div className='container container__header'>
+          <h1 className='page__header'>
+            Open Source Data for Professionals and Developers
+          </h1>
+          <p className='page__contentDescrip'>
+            You are exploring all available scraped datasets from all
+            categories. Available data includes reactor information related to
+            design specifications, reactor core, coolant system, core materials,
+            and more. If you find new data or would like to provide updates,
+            feel free to login and submit a request.
+          </p>
+        </div>
       </div>
       <div className='container container__flex'>
         {/* sidebar containing filtering for reactors */}

--- a/src/pages/Reactors.jsx
+++ b/src/pages/Reactors.jsx
@@ -18,11 +18,13 @@ function Reactors({ data }) {
         </p>
       </div>
       <div className='container container__flex'>
+        {/* sidebar containing filtering for reactors */}
         <div className='col col--side'>
           <div className='container__sidebar'>
             <h2 className='sidebar__title'>Categories</h2>
           </div>
         </div>
+        {/* Displays all reactors in cards */}
         <div className='col col--main'>
           <div className='container__scrollMain'>
             <h2>Reactors</h2>

--- a/src/pages/Reactors.jsx
+++ b/src/pages/Reactors.jsx
@@ -1,4 +1,5 @@
 import '../assets/App.css';
+import ReactorCard from '../components/ReactorCard';
 import Footer from '../components/Footer';
 
 function Reactors({ data }) {
@@ -19,12 +20,13 @@ function Reactors({ data }) {
       <div className='container container__flex'>
         <div className='col col--side'>
           <div className='container__sidebar'>
-            <h2>Categories</h2>
+            <h2 className='sidebar__title'>Categories</h2>
           </div>
         </div>
         <div className='col col--main'>
           <div className='container__scrollMain'>
             <h2>Reactors</h2>
+            <ReactorCard data={data} />
           </div>
         </div>
       </div>

--- a/src/pages/Reactors.jsx
+++ b/src/pages/Reactors.jsx
@@ -1,7 +1,7 @@
 import '../assets/App.css';
 import Footer from '../components/Footer';
 
-function Reactors() {
+function Reactors({ data }) {
   return (
     <section className='section__reactors'>
       <div className='container container__reactors'>
@@ -15,6 +15,18 @@ function Reactors() {
           more. If you find new data or would like to provide updates, feel free
           to login and submit a request.
         </p>
+      </div>
+      <div className='container container__flex'>
+        <div className='col col--side'>
+          <div className='container__sidebar'>
+            <h2>Categories</h2>
+          </div>
+        </div>
+        <div className='col col--main'>
+          <div className='container__scrollMain'>
+            <h2>Reactors</h2>
+          </div>
+        </div>
       </div>
       <Footer />
     </section>


### PR DESCRIPTION
Resolves #2

- built off of `/reactors` route
- adds view to see all reactors
- displays results in cards with popup modals for expanded info
- create sidebar UI to filter results (not complete)